### PR TITLE
Fix issues related to using a modern version of the PSP toolchain

### DIFF
--- a/.github/workflows/Suicide_Barbie.yml
+++ b/.github/workflows/Suicide_Barbie.yml
@@ -10,45 +10,104 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Retrieve commit hash
+      id: psptoolchain
+      run: echo "::set-output name=sha::$(git -C psptoolchain rev-parse HEAD)"
+        
+    - name: Cache PSP toolchain
+      uses: actions/cache@v2
+      id: cache-psptoolchain
+      with:
+        path: pspdev
+        key: ${{ runner.os }}-psptoolchain-${{ steps.psptoolchain.outputs.sha }}
 
     - name: Install deps
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
       run: sudo apt install autoconf automake bison flex gcc-9 libncurses-dev make subversion texinfo wget libusb-dev
       
     - name: Bootstrap
-      run: |
-        cd $GITHUB_WORKSPACE
-        ./bootstrap.sh
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
+      run: ./bootstrap.sh
 
     - name: Clean
-      run: |
-        cd $GITHUB_WORKSPACE
-        ./clean.sh
+      run: ./clean.sh
 
     - name: Build
-      run: |
-        cd $GITHUB_WORKSPACE
-        ./build.sh
+      run: ./build.sh
 
   macOS:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Retrieve commit hash
+      id: psptoolchain
+      run: echo "::set-output name=sha::$(git -C psptoolchain rev-parse HEAD)"
+        
+    - name: Cache PSP toolchain
+      uses: actions/cache@v2
+      id: cache-psptoolchain
+      with:
+        path: pspdev
+        key: ${{ runner.os }}-psptoolchain-${{ steps.psptoolchain.outputs.sha }}
 
     - name: Install deps
-      run: |
-        brew install autoconf automake flex gcc@9 ncurses make subversion texinfo wget libusb libusb-compat sdl
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
+      run: brew install autoconf automake flex gcc@9 ncurses make subversion texinfo wget libusb libusb-compat sdl
       
     - name: Bootstrap
-      run: |
-        cd $GITHUB_WORKSPACE
-        ./bootstrap.sh
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
+      run: ./bootstrap.sh
 
     - name: Clean
-      run: |
-        cd $GITHUB_WORKSPACE
-        ./clean.sh
+      run: ./clean.sh
 
     - name: Build
+      run: ./build.sh
+        
+
+  Linux-latest-pspdev:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout the main repo
+      uses: actions/checkout@v2
+
+    - name: Checkout the latest PSP toolchain script
+      uses: actions/checkout@v2
+      with:
+        repository: pspdev/psptoolchain
+        path: psptoolchain
+
+    - name: Retrieve commit hash
+      id: psptoolchain
+      run: echo "::set-output name=sha::$(git -C psptoolchain rev-parse HEAD)"
+        
+    - name: Cache PSP toolchain
+      uses: actions/cache@v2
+      id: cache-psptoolchain
+      with:
+        path: pspdev
+        key: ${{ runner.os }}-psptoolchain-${{ steps.psptoolchain.outputs.sha }}
+
+    - name: Install deps
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
+      run: ./prepare-debian-ubuntu.sh
+
+    - name: Bootstrap
+      if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
       run: |
-        cd $GITHUB_WORKSPACE
-        ./build.sh
+        export PSPDEV=$(pwd)/pspdev
+        export PATH=$PATH:$PSPDEV/bin
+        cd psptoolchain
+        ./toolchain.sh
+
+    - name: Clean
+      run: ./clean.sh
+
+    - name: Build
+      run: ./build.sh

--- a/.github/workflows/Suicide_Barbie.yml
+++ b/.github/workflows/Suicide_Barbie.yml
@@ -96,7 +96,9 @@ jobs:
 
     - name: Install deps
       if: steps.cache-psptoolchain.outputs.cache-hit != 'true'
-      run: ./prepare-debian-ubuntu.sh
+      run: |
+        cd psptoolchain
+        ./prepare-debian-ubuntu.sh
 
     - name: Bootstrap
       if: steps.cache-psptoolchain.outputs.cache-hit != 'true'

--- a/Code/ForcedInclude.h
+++ b/Code/ForcedInclude.h
@@ -7,9 +7,6 @@
 	#if defined(PSP_FINAL) && defined(NDEBUG)
 
 		#include <stdio.h>
-		#ifdef __cplusplus
-			#include <stdexcept>
-		#endif
 		#include <pspdebug.h>
 		#include <pspkdebug.h>
 		#define __STDIO_H__ 

--- a/Code/ForcedInclude.h
+++ b/Code/ForcedInclude.h
@@ -1,6 +1,6 @@
 #if defined(__psp__)		// PSP specific global define overides...
 	#define PSP_FINAL		// define to remove printf flooding etc
-	#if defined(PSP_FINAL)
+	#if defined(PSP_FINAL) && defined(NDEBUG)
 
 		#include <stdio.h>
 		#ifdef __cplusplus

--- a/Code/ForcedInclude.h
+++ b/Code/ForcedInclude.h
@@ -1,4 +1,8 @@
 #if defined(__psp__)		// PSP specific global define overides...
+	#ifdef __cplusplus
+		#include <stdexcept>
+	#endif
+
 	#define PSP_FINAL		// define to remove printf flooding etc
 	#if defined(PSP_FINAL) && defined(NDEBUG)
 
@@ -14,6 +18,15 @@
 		#define pspDebugScreenInit() do {} while(0)
 		#define pspDebugScreenSetOffset(i) do {} while(0)
 		#define pspDebugScreenSetXY(x, y) do {} while(0)
+	#endif
+
+
+	#include <string.h>
+
+	// This mimics the behavior of GCC 4.1.0 with -fno-exceptions
+	#if !defined(try)
+		#define try      if (1)
+		#define catch(x) if (0)
 	#endif
 
 #endif

--- a/Code/Makefile
+++ b/Code/Makefile
@@ -1,15 +1,18 @@
 .SUFFIXES:
 
-.PHONY: debug release release_oe clean libs libs_debug elf elf_debug prx
+.PHONY: debug release debug_oe release_oe clean libs libs_debug elf elf_debug prx prx_debug
 .EXPORT_ALL_VARIABLES:
 
-all: debug release release_oe
+all: debug release debug_oe release_oe
 
 debug: CONFIG = DEBUG
 debug: elf_debug
 release: elf
 release_oe: BUILD_OE = 1
 release_oe: prx
+debug_oe: CONFIG = DEBUG
+debug_oe: BUILD_OE = 1
+debug_oe: prx_debug
 
 libs_debug:
 	@$(MAKE) $(MAKEFLAGS) -C zlib LIB
@@ -43,6 +46,9 @@ elf: libs
 	@$(MAKE) $(MAKEFLAGS) -C Tests/MutaliskViewer PBP
 
 prx: libs
+	@$(MAKE) $(MAKEFLAGS) -C Tests/MutaliskViewer PBP
+
+prx_debug: libs_debug
 	@$(MAKE) $(MAKEFLAGS) -C Tests/MutaliskViewer PBP
 
 clean:

--- a/Code/Modules/mutalisk/malloc.cpp
+++ b/Code/Modules/mutalisk/malloc.cpp
@@ -32,7 +32,8 @@ public:
 extern "C"
 {
 
-void* __wrap_malloc(size_t size)
+// Use 'noinline' here as we don't want it to unroll into __wrap_calloc below
+void* __attribute__ ((noinline)) __wrap_malloc(size_t size)
 {
 	ScopedMutex scoped(mutex);
 	return dlmalloc(size);
@@ -72,7 +73,7 @@ void __wrap_free(void* size)
 
 void* __wrap_calloc(size_t numelems, size_t sizeofeach)
 {
-	void* p = malloc(numelems * sizeofeach);
+	void* p = __wrap_malloc(numelems * sizeofeach);
 	if (!p)
 		return 0;
 	memset(p, 0x00, numelems * sizeofeach);

--- a/Code/Modules/mutant/mutant/binary_compressed_input.cpp
+++ b/Code/Modules/mutant/mutant/binary_compressed_input.cpp
@@ -1,12 +1,18 @@
 #include "binary_compressed_input.h"
+#if !defined(__psp__)
 #include <iostream>
+#endif
 
 using namespace mutant;
 
 template<typename _A>
 void CHECK_ERR( int e, _A const& a )  {
 	if( e!=Z_OK )
+#if defined(__psp__)
+		printf("ZLIB ERROR: (%i) %s\n", e, a);
+#else
 		std::cerr << "ZLIB ERROR: (" << e << ") " << (a) << std::endl;
+#endif
 }
 
 mutant_compressed_input::mutant_compressed_input( std::auto_ptr<binary_input>& input )

--- a/Code/Modules/mutant/mutant/binary_compressed_output.cpp
+++ b/Code/Modules/mutant/mutant/binary_compressed_output.cpp
@@ -1,13 +1,17 @@
 #include "binary_compressed_output.h"
+#if !defined(__psp__)
 #include <iostream>
+#endif
 
 using namespace mutant;
 
 template<typename _A>
 void CHECK_ERR( int e, _A const& a )
 {
+#if !defined(__psp__)
 	if(e!=Z_OK)
 		std::cerr << "ZLIB ERROR: (" << e << ") " << (a) << std::endl;
+#endif
 }
 
 mutant_compressed_output::mutant_compressed_output( std::auto_ptr<binary_output>& output )
@@ -62,6 +66,7 @@ void mutant_compressed_output::initDeflate()
 	zstream.opaque = (voidpf)0;
 
 	err = deflateInit(&zstream, Z_DEFAULT_COMPRESSION);
+	CHECK_ERR( err, "initDeflate" );
 
 	zstream.next_out = mBuffer;
 	zstream.avail_out = BUF_LEN;

--- a/Code/Modules/mutant/mutant/clip.h
+++ b/Code/Modules/mutant/mutant/clip.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <algorithm>
+#include <memory>
 
 //#include <boost/compose.hpp>
 

--- a/Code/Modules/player/ScenePlayer.h
+++ b/Code/Modules/player/ScenePlayer.h
@@ -295,8 +295,16 @@ static AP<ResourceType> loadResource(std::string fileName)
 	return resource;
 }
 
+// When using a newer toolchain than the original 4.1.0 (like 9.3.0)
+// the template specialization requires different handling
+#if __GNUC__ > 4
+#define INLINE inline
+#else
+#define INLINE static
+#endif
+
 template <>
-static AP<mutant::anim_character_set> loadResource(std::string fileName)
+INLINE AP<mutant::anim_character_set> loadResource(std::string fileName)
 {
 	;;printf("loadResource<anim_character_set>: $ %s\n", fileName.c_str());
 	AP<mutant::mutant_reader> reader = createFileReader(fileName);
@@ -307,7 +315,7 @@ static AP<mutant::anim_character_set> loadResource(std::string fileName)
 }
 
 template <>
-static AP<mutalisk::data::texture> loadResource(std::string fileName)
+INLINE AP<mutalisk::data::texture> loadResource(std::string fileName)
 {
 	;;printf("loadResource<mutalisk::data::texture>: $ %s\n", fileName.c_str());
 	AP<mutant::binary_input> input = AP<mutant::binary_input>(new file_input(getResourcePath() + fileName));
@@ -319,6 +327,8 @@ static AP<mutalisk::data::texture> loadResource(std::string fileName)
 	;;printf("loadResource<mutalisk::data::texture>: ! %s\n", fileName.c_str());
 	return resource;
 }
+
+#undef INLINE
 
 #ifdef AP_DEFINED_LOCALY
 #undef AP

--- a/Code/Tests/MutaliskViewer/Makefile
+++ b/Code/Tests/MutaliskViewer/Makefile
@@ -23,7 +23,6 @@ LIBS=\
 	$(PSPDEV)/psp/sdk/lib/libpspdisplay.a\
 	$(PSPDEV)/psp/sdk/lib/libpspctrl.a\
 	$(PSPDEV)/psp/sdk/lib/libpspnet.a\
-	$(PSPDEV)/psp/sdk/lib/libpspnet_inet.a\
 	$(PSPDEV)/psp/sdk/lib/libpspdebug.a\
 	$(OUTDIR)/effects.lib\
 	$(OUTDIR)/player.lib\
@@ -58,9 +57,11 @@ SRCS=\
 
 ifeq ($(BUILD_OE),1)
 CC_FLAGS+=-DPSP_OE
+# This is the standard linkscript, but KEEP()'ing sceModuleInfo from being collected by --gc-sections
+LCFILE = linkfile.prx
 LD_FLAGS=\
 	-specs=$(PSPDEV)/psp/sdk/lib/prxspecs\
-	-Wl,-q,-T$(PSPDEV)/psp/sdk/lib/linkfile.prx\
+	-Wl,-q,-T$(LCFILE)\
 	$(PSPDEV)/psp/sdk/lib/prxexports.o\
 	-fno-exceptions\
 	-Wl,-Map="$(OUTDIR)/$(PROJECT).prx.txt"\

--- a/Code/Tests/MutaliskViewer/linkfile.prx
+++ b/Code/Tests/MutaliskViewer/linkfile.prx
@@ -3,7 +3,7 @@ OUTPUT_FORMAT("elf32-littlemips", "elf32-bigmips",
 	      "elf32-littlemips")
 OUTPUT_ARCH(mips:allegrex)
 ENTRY(module_start)
-SEARCH_DIR("/Users/erik/src/psptoolchain/pspdev/psp/lib");
+SEARCH_DIR("/usr/local/pspdev/psp/lib");
 /* Do we need any of these for elf?
    __DYNAMIC = 0;    */
 SECTIONS

--- a/Code/Tests/MutaliskViewer/linkfile.prx
+++ b/Code/Tests/MutaliskViewer/linkfile.prx
@@ -1,0 +1,247 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-littlemips", "elf32-bigmips",
+	      "elf32-littlemips")
+OUTPUT_ARCH(mips:allegrex)
+ENTRY(module_start)
+SEARCH_DIR("/Users/erik/src/psptoolchain/pspdev/psp/lib");
+/* Do we need any of these for elf?
+   __DYNAMIC = 0;    */
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  PROVIDE (__executable_start = 0x0); . = 0x0;
+  .interp         : { *(.interp) }
+  .dynamic        : { *(.dynamic) }
+  .hash           : { *(.hash) }
+  .dynsym         : { *(.dynsym) }
+  .dynstr         : { *(.dynstr) }
+  .gnu.version    : { *(.gnu.version) }
+  .gnu.version_d  : { *(.gnu.version_d) }
+  .gnu.version_r  : { *(.gnu.version_r) }
+  .rel.text       : { *(.rel.text .rel.text.* .rel.gnu.linkonce.t.*) }
+  .rela.text      : { *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*) }
+  .rel.init       : { *(.rel.init) }
+  .rela.init      : { *(.rela.init) }
+  .rel.fini       : { *(.rel.fini) }
+  .rela.fini      : { *(.rela.fini) }
+  /* PSP-specific relocations. */
+  .rel.sceStub.text   : { *(.rel.sceStub.text) *(SORT(.rel.sceStub.text.*)) }
+  .rel.lib.ent.top    : { *(.rel.lib.ent.top) }
+  .rel.lib.ent        : { *(.rel.lib.ent) }
+  .rel.lib.ent.btm    : { *(.rel.lib.ent.btm) }
+  .rel.lib.stub.top   : { *(.rel.lib.stub.top) }
+  .rel.lib.stub       : { *(.rel.lib.stub) }
+  .rel.lib.stub.btm   : { *(.rel.lib.stub.btm) }
+  .rel.rodata.sceModuleInfo   : { *(.rel.rodata.sceModuleInfo) }
+  .rel.rodata.sceResident     : { *(.rel.rodata.sceResident) }
+  .rel.rodata.sceNid          : { *(.rel.rodata.sceNid) }
+  .rel.rodata.sceVstub        : { *(.rel.rodata.sceVstub) *(SORT(.rel.rodata.sceVstub.*)) }
+  .rel.rodata     : { *(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*) }
+  .rela.rodata    : { *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*) }
+  .rel.data.rel.ro   : { *(.rel.data.rel.ro*) }
+  .rela.data.rel.ro   : { *(.rel.data.rel.ro*) }
+  .rel.data       : { *(.rel.data .rel.data.* .rel.gnu.linkonce.d.*) }
+  .rela.data      : { *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*) }
+  .rel.tdata	  : { *(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*) }
+  .rela.tdata	  : { *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*) }
+  .rel.tbss	  : { *(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*) }
+  .rela.tbss	  : { *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*) }
+  .rel.ctors      : { *(.rel.ctors) }
+  .rela.ctors     : { *(.rela.ctors) }
+  .rel.dtors      : { *(.rel.dtors) }
+  .rela.dtors     : { *(.rela.dtors) }
+  .rel.got        : { *(.rel.got) }
+  .rela.got       : { *(.rela.got) }
+  .rel.sdata      : { *(.rel.sdata .rel.sdata.* .rel.gnu.linkonce.s.*) }
+  .rela.sdata     : { *(.rela.sdata .rela.sdata.* .rela.gnu.linkonce.s.*) }
+  .rel.sbss       : { *(.rel.sbss .rel.sbss.* .rel.gnu.linkonce.sb.*) }
+  .rela.sbss      : { *(.rela.sbss .rela.sbss.* .rela.gnu.linkonce.sb.*) }
+  .rel.sdata2     : { *(.rel.sdata2 .rel.sdata2.* .rel.gnu.linkonce.s2.*) }
+  .rela.sdata2    : { *(.rela.sdata2 .rela.sdata2.* .rela.gnu.linkonce.s2.*) }
+  .rel.sbss2      : { *(.rel.sbss2 .rel.sbss2.* .rel.gnu.linkonce.sb2.*) }
+  .rela.sbss2     : { *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*) }
+  .rel.bss        : { *(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*) }
+  .rela.bss       : { *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*) }
+  .rel.plt        : { *(.rel.plt) }
+  .rela.plt       : { *(.rela.plt) }
+  .text           :
+  {
+    _ftext = . ;
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+    KEEP (*(.text.*personality*))
+    /* .gnu.warning sections are handled specially by elf32.em.  */
+    *(.gnu.warning)
+    *(.mips16.fn.*) *(.mips16.call.*)
+  } =0
+  .init           :
+  {
+    KEEP (*(.init))
+  } =0
+  .plt            : { *(.plt) }
+  .fini           :
+  {
+    KEEP (*(.fini))
+  } =0
+  /* PSP library stub functions. */
+  .sceStub.text     : { *(.sceStub.text) *(SORT(.sceStub.text.*)) }
+  PROVIDE (__etext = .);
+  PROVIDE (_etext = .);
+  PROVIDE (etext = .);
+  /* PSP library entry table and library stub table. */
+  .lib.ent.top    : { *(.lib.ent.top) }
+  .lib.ent        : { *(.lib.ent) }
+  .lib.ent.btm    : { *(.lib.ent.btm) }
+  .lib.stub.top   : { *(.lib.stub.top) }
+  .lib.stub       : { *(.lib.stub) }
+  .lib.stub.btm   : { *(.lib.stub.btm) }
+  /* PSP read-only data for module info, NIDs, and Vstubs.  The
+     .rodata.sceModuleInfo section must appear before the .rodata section
+     otherwise it would get absorbed into .rodata and the PSP bootloader
+     would be unable to locate the module info structure. */
+  /* Add 'KEEP' of sceModuleInfo to allow Suicide Barbie to link with --gc-sections */
+  .rodata.sceModuleInfo    : { KEEP (*(.rodata.sceModuleInfo)) }
+  .rodata.sceResident      : { *(.rodata.sceResident) }
+  .rodata.sceNid           : { KEEP (*(.rodata.sceNid)) }
+  .rodata.sceVstub         : { *(.rodata.sceVstub) *(SORT(.rodata.sceVstub.*)) }
+  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) }
+  .rodata1        : { *(.rodata1) }
+  .sdata2         : { *(.sdata2 .sdata2.* .gnu.linkonce.s2.*) }
+  .sbss2          : { *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*) }
+  .eh_frame_hdr : { *(.eh_frame_hdr) }
+  .eh_frame       : ONLY_IF_RO { KEEP (*(.eh_frame)) }
+  .gcc_except_table   : ONLY_IF_RO { KEEP (*(.gcc_except_table)) *(.gcc_except_table.*) }
+  /* Adjust the address for the data segment.  We want to adjust up to
+     the same address within the page on the next page up.  */
+  . = ALIGN(256) + (. & (256 - 1));
+  /* Exception handling  */
+  .eh_frame       : ONLY_IF_RW { KEEP (*(.eh_frame)) }
+  .gcc_except_table   : ONLY_IF_RW { KEEP (*(.gcc_except_table)) *(.gcc_except_table.*) }
+  /* Thread Local Storage sections  */
+  .tdata	  : { *(.tdata .tdata.* .gnu.linkonce.td.*) }
+  .tbss		  : { *(.tbss .tbss.* .gnu.linkonce.tb.*) *(.tcommon) }
+  /* Ensure the __preinit_array_start label is properly aligned.  We
+     could instead move the label definition inside the section, but
+     the linker would then create the section even if it turns out to
+     be empty, which isn't pretty.  */
+  . = ALIGN(32 / 8);
+  PROVIDE (__preinit_array_start = .);
+  .preinit_array     : { KEEP (*(.preinit_array)) }
+  PROVIDE (__preinit_array_end = .);
+  PROVIDE (__init_array_start = .);
+  .init_array     : { KEEP (*(.init_array)) }
+  PROVIDE (__init_array_end = .);
+  PROVIDE (__fini_array_start = .);
+  .fini_array     : { KEEP (*(.fini_array)) }
+  PROVIDE (__fini_array_end = .);
+  .ctors          :
+  {
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin*.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE (*crtend*.o ) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+  }
+  .dtors          :
+  {
+    KEEP (*crtbegin*.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend*.o ) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+  }
+  .jcr            : { KEEP (*(.jcr)) }
+  .data.rel.ro : { *(.data.rel.ro.local) *(.data.rel.ro*) }
+  .data           :
+  {
+    _fdata = . ;
+    *(.data .data.* .gnu.linkonce.d.*)
+    KEEP (*(.gnu.linkonce.d.*personality*))
+    SORT(CONSTRUCTORS)
+  }
+  .data1          : { *(.data1) }
+  . = .;
+  _gp = ALIGN(16) + 0x7ff0;
+  .got            : { *(.got.plt) *(.got) }
+  /* We want the small data sections together, so single-instruction offsets
+     can access them all, and initialized data all before uninitialized, so
+     we can shorten the on-disk segment size.  */
+  .sdata          :
+  {
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
+  }
+  .lit8           : { *(.lit8) }
+  .lit4           : { *(.lit4) }
+  _edata = .;
+  PROVIDE (edata = .);
+  __bss_start = .;
+  _fbss = .;
+  .sbss           :
+  {
+    PROVIDE (__sbss_start = .);
+    PROVIDE (___sbss_start = .);
+    *(.dynsbss)
+    *(.sbss .sbss.* .gnu.linkonce.sb.*)
+    *(.scommon)
+    PROVIDE (__sbss_end = .);
+    PROVIDE (___sbss_end = .);
+  }
+  .bss            :
+  {
+   *(.dynbss)
+   *(.bss .bss.* .gnu.linkonce.b.*)
+   *(COMMON)
+   /* Align here to ensure that the .bss section occupies space up to
+      _end.  Align after .bss to ensure correct alignment even if the
+      .bss section disappears because there are no input sections.  */
+   . = ALIGN(32 / 8);
+  }
+  . = ALIGN(32 / 8);
+  _end = .;
+  PROVIDE (end = .);
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /DISCARD/ : { *(.comment) *(.pdr) }
+  /DISCARD/ : { *(.note.GNU-stack) }
+}

--- a/Code/build.mak
+++ b/Code/build.mak
@@ -52,6 +52,8 @@ CC_FLAGS_COMMON=\
 	-include "ForcedInclude.h"\
 	-MMD    \
 	-Wall\
+	-Wno-deprecated-declarations\
+	-D__CORRECT_ISO_CPP_MATH_H_PROTO\
 	-fno-exceptions\
 
 CC_FLAGS_DEBUG=\

--- a/Code/build.mak
+++ b/Code/build.mak
@@ -16,9 +16,14 @@ PROJECT ?= $(notdir $(PROJECT_DIRNAME))
 ########################################################
 
 CONFIG?=RELEASE
+VARIANT=$(CONFIG)
+
+ifeq ($(BUILD_OE),1)
+VARIANT:=$(CONFIG)_OE
+endif
 
 OUTDIR = $(ROOT)/Output/$(CONFIG)
-INTDIR = $(ROOT)/Build/$(CONFIG)/$(PROJECT)
+INTDIR = $(ROOT)/Build/$(VARIANT)/$(PROJECT)
 
 $(info ~~~~~~~~~~~~~ PROJECT = $(PROJECT) ; CONFIG = $(CONFIG))
 

--- a/Code/build.mak
+++ b/Code/build.mak
@@ -54,6 +54,7 @@ CC_FLAGS_COMMON=\
 	-Wall\
 	-Wno-deprecated-declarations\
 	-D__CORRECT_ISO_CPP_MATH_H_PROTO\
+	-ffunction-sections -fdata-sections\
 	-fno-exceptions\
 
 CC_FLAGS_DEBUG=\

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ cd "`dirname $0`" || { echo "ERROR: Could not enter the repo root directory."; e
 
 if [ -z "$1" ]
 then
-	TARGET="release"
+	TARGET="all"
 else
 	TARGET="$1"
 fi	
@@ -38,8 +38,8 @@ if test -f "Code/Makefile"; then
 fi
 
 if test -d "ReleaseCandidate"; then
-	cp -r Output/RELEASE/%__SCE__SuicideBarbie ReleaseCandidate/
-	cp -r Output/RELEASE/__SCE__SuicideBarbie ReleaseCandidate/
+	[ -d Output/RELEASE/%__SCE__SuicideBarbie ] && cp -r Output/RELEASE/%__SCE__SuicideBarbie ReleaseCandidate/
+	[ -d Output/RELEASE/__SCE__SuicideBarbie  ] && cp -r Output/RELEASE/__SCE__SuicideBarbie ReleaseCandidate/
 
-	psp-size ReleaseCandidate/__SCE__SuicideBarbie/EBOOT.PBP
+	psp-size Output/*/SuicideBarbie*.elf ReleaseCandidate/__SCE__SuicideBarbie/EBOOT.PBP
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,37 @@ set -e
 
 cd "`dirname $0`" || { echo "ERROR: Could not enter the repo root directory."; exit 1; }
 
-export PSPDEV=$PWD/pspdev
-export PATH=$PATH:$PSPDEV/bin
+if [ -z "$1" ]
+then
+	TARGET="release"
+else
+	TARGET="$1"
+fi	
+
+if [ -z "$PSPDEV" ]
+then
+	echo "PSPDEV not set.."
+	export PSPDEV=$PWD/pspdev
+	export PATH=$PATH:$PSPDEV/bin
+fi
+
+if command -v psp-config &> /dev/null
+then
+	CONFIG_PATH=`which psp-config`
+	if [[ x"$CONFIG_PATH" != x"$PSPDEV/bin/psp-config" ]]
+	then
+		diff <(echo "$CONFIG_PATH" ) <(echo "$PSPDEV/bin/psp-config") || true
+		echo "ERROR: pspdev path is different from \$PSPDEV; Multiple installations?"; exit 1;
+	fi
+else
+	echo "ERROR: No PSP toolchain? Run ./bootstrap.sh"; exit 1;
+fi
+
+echo "PSPDEV=$PSPDEV"
+echo "TARGET=$TARGET"
 
 if test -f "Code/Makefile"; then
-	make -j4 --no-print-directory -C Code release
+	make -j4 --no-print-directory -C Code $TARGET
 fi
 
 if test -d "ReleaseCandidate"; then

--- a/psplink.sh
+++ b/psplink.sh
@@ -4,8 +4,16 @@ set -e
 
 cd "`dirname $0`" || { echo "ERROR: Could not enter the repo root directory."; exit 1; }
 
-export PSPDEV=$PWD/pspdev
-export PATH=$PATH:$PSPDEV/bin
+if [ -z "$PSPDEV" ]
+then
+	export PSPDEV=$PWD/pspdev
+	export PATH=$PATH:$PSPDEV/bin
+fi
+
+if ! command -v usbhostfs_pc &> /dev/null
+then
+	echo "ERROR: No usbhostfs_pc? Run ./bootstrap.sh"; exit 1;
+fi
 
 killall usbhostfs_pc || echo "no usbhostfs_pc found"
 usbhostfs_pc -mcd Output/RELEASE ReleaseCandidate/__SCE__SuicideBarbie/BarbieData &

--- a/psplink.sh
+++ b/psplink.sh
@@ -16,7 +16,7 @@ then
 fi
 
 killall usbhostfs_pc || echo "no usbhostfs_pc found"
-usbhostfs_pc -mcd Output/RELEASE ReleaseCandidate/__SCE__SuicideBarbie/BarbieData &
+usbhostfs_pc -mcd Output/RELEASE ReleaseCandidate/__SCE__SuicideBarbie/BarbieData Output/DEBUG &
 
 while ! nc -z localhost 10000; do
   sleep 0.1


### PR DESCRIPTION
As far as codegen goes GCC 9.3.0 creates a slightly bigger .text section (78kB (20%) for the .elf; 36kB (9%) for the .prx), but with roughly the same performance (all else equal / original compile settings).
